### PR TITLE
Improve error display and fix typos

### DIFF
--- a/zephyr/src/error.rs
+++ b/zephyr/src/error.rs
@@ -26,7 +26,13 @@ impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "zephyr error errno:{}", self.0)
+        
+        let error_name = match self.0 {
+            1 => "EPERM", 2 => "ENOENT", 3 => "ESRCH", 4 => "EINTR", 5 => "EIO",
+            11 => "EAGAIN", 12 => "ENOMEM", 13 => "EACCES", 16 => "EBUSY", 22 => "EINVAL",
+            _ => "Unknown",
+        };
+        write!(f, "Zephyr error: {} (errno:{})", error_name, self.0)
     }
 }
 
@@ -53,4 +59,9 @@ pub fn to_result(code: c_int) -> Result<c_int> {
 /// Map a return result, with a void result.
 pub fn to_result_void(code: c_int) -> Result<()> {
     to_result(code).map(|_| ())
+}
+
+/// Check if a return code indicates success (>= 0)
+pub fn is_success(code: c_int) -> bool {
+    code >= 0
 }

--- a/zephyr/src/sync/mutex.rs
+++ b/zephyr/src/sync/mutex.rs
@@ -60,7 +60,7 @@ impl<T> fmt::Debug for Mutex<T> {
     }
 }
 
-/// An RAII implementation of a "scoped lock" of a mutex.  When this structure is dropped (faslls
+/// An RAII implementation of a "scoped lock" of a mutex.  When this structure is dropped (falls
 /// out of scope), the lock will be unlocked.
 ///
 /// The data protected by the mutex can be accessed through this guard via its [`Deref`] and

--- a/zephyr/src/time.rs
+++ b/zephyr/src/time.rs
@@ -35,6 +35,7 @@ compile_error!("Rust does not (yet) support dynamic frequency timer");
 
 // Given the above not defined, the system time base comes from a kconfig.
 /// The system time base.  The system clock has this many ticks per second.
+/// This is typically 1000 Hz for most Zephyr configurations.
 pub const SYS_FREQUENCY: u32 = crate::kconfig::CONFIG_SYS_CLOCK_TICKS_PER_SEC as u32;
 
 /// Zephyr can be configured for either 64-bit or 32-bit time values.  Use the appropriate type


### PR DESCRIPTION
should we add Add these changes？

Add friendly error names and fix mutex documentation typo